### PR TITLE
Add jenv init to fish script

### DIFF
--- a/conf.d/jenv.fish
+++ b/conf.d/jenv.fish
@@ -16,3 +16,5 @@ set -x PATH "$jenv_root/shims" $PATH
 set -x JENV_SHELL fish
 
 command mkdir -p "$jenv_root/"{shims,versions}
+
+status --is-interactive; and source (jenv init -|psub)


### PR DESCRIPTION
Otherwise the export plugin does not work properly, causing prompts to show the wrong JDK version.